### PR TITLE
現在時刻挿入ボタンの秒挿入を削除

### DIFF
--- a/app/assets/javascripts/time_records.coffee
+++ b/app/assets/javascripts/time_records.coffee
@@ -14,9 +14,7 @@ $( ->
     now_string = ''.concat(
       stretchTimeFormat(now.getHours()),
       ':',
-      stretchTimeFormat(now.getMinutes()),
-      ':',
-      stretchTimeFormat(now.getSeconds())
+      stretchTimeFormat(now.getMinutes())
     )
 
     input = $(@).parent().children('input[type="time"]').get(0)


### PR DESCRIPTION
Web ブラウザのバリデーションで弾かれるため