### PR TITLE
土日祝祭日を除いた勤務日合計を算出するメソッドの作成

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,6 +31,8 @@ gem 'jbuilder', '~> 2.5'
 # Use Capistrano for deployment
 # gem 'capistrano-rails', group: :development
 
+gem 'holiday_japan'
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platform: :mri

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -124,6 +124,7 @@ GEM
     guard-rubocop (1.2.0)
       guard (~> 2.0)
       rubocop (~> 0.20)
+    holiday_japan (1.2.2)
     i18n (0.7.0)
     ice_nine (0.11.2)
     jbuilder (2.6.0)
@@ -374,6 +375,7 @@ DEPENDENCIES
   guard
   guard-rspec
   guard-rubocop
+  holiday_japan
   jbuilder (~> 2.5)
   jquery-rails
   launchy

--- a/app/controllers/time_records_controller.rb
+++ b/app/controllers/time_records_controller.rb
@@ -8,6 +8,7 @@ class TimeRecordsController < ApplicationController
     @time_record = TimeRecord.find_by_work_date(params[:work_date] || Date.today)
 
     @work_time = calculate_work_time(@time_records)
+    @workdays_of_month = TimeRecord.workdays_of_month(month: @month, year: @year)
   end
 
   # GET /time_records/1

--- a/app/views/time_records/index.html.slim
+++ b/app/views/time_records/index.html.slim
@@ -65,7 +65,7 @@ br
           td = link_to '削除', time_record, data: { confirm: '本当に削除しますか?' }, method: :delete
       tr
         td &nbsp;
-        td.text-center colspan="2" = "満勤 #{@time_records.find_all{ |r| (0..4).include?(r.work_date.wday) }.size}"
+        td.text-center colspan="2" = "満勤 #{@workdays_of_month}"
         td &nbsp;
         td &nbsp;
         td = worked_time(@work_time)


### PR DESCRIPTION
土日祝祭日を除いた、勤務日合計を算出する機能を追加します

現状では、祝祭日の算出を考慮できていないので、それを修正します

Ref : `app/views/time_records/index.html.slim` : L68 ( [time_keeper/index.html.slim at feature/collect_count_work_day_of_month · gouf/time_keeper](https://github.com/gouf/time_keeper/blob/feature/collect_count_work_day_of_month/app/views/time_records/index.html.slim#L68))